### PR TITLE
fix field table parsing when typeInfoAddr is 0

### DIFF
--- a/DelphiHelper/core/DelphiClass_FieldTable.py
+++ b/DelphiHelper/core/DelphiClass_FieldTable.py
@@ -59,7 +59,7 @@ class FieldTable(object):
             MakeCustomWord(addr + 1, self.__processorWordSize)
             typeInfoAddr = GetCustomWord(addr + 1, self.__processorWordSize)
 
-            if ida_bytes.is_loaded(typeInfoAddr):
+            if typeInfoAddr == 0 or ida_bytes.is_loaded(typeInfoAddr):
                 if typeInfoAddr == 0:
                     typeName = "NoType"
                 else:
@@ -107,6 +107,11 @@ class FieldTable(object):
         ida_bytes.set_cmt(
             self.__tableAddr + 2,
             "Class table",
+            0
+        )
+        ida_bytes.set_cmt(
+            self.__tableAddr + 2 + self.__processorWordSize,
+            "Number of fields",
             0
         )
 


### PR DESCRIPTION
when typeInfoAddr is 0 and its not loaded (`ida_bytes.is_loaded(typeInfoAddr`) , [___CreateExtendedTableAndExtractData](https://github.com/eset/DelphiHelper/blob/08c1865a0f729266196844704d86104df224aa25/DelphiHelper/core/DelphiClass_FieldTable.py#L62) early exits.  This PR fixes it. Also, I added "Number of fields" comment to Field Table struct 

![2025-02-24_12-37](https://github.com/user-attachments/assets/ecfef037-2920-44d7-bfd9-b125b602041e)

![2025-02-24_12-46](https://github.com/user-attachments/assets/916c7abe-d7ad-415f-80c3-8cf8b32fcff6)



