### PR TITLE
Update IDRKBParser.py

### DIFF
--- a/DelphiHelper/core/IDRKBParser.py
+++ b/DelphiHelper/core/IDRKBParser.py
@@ -135,7 +135,7 @@ class KBParser(object):
             firstIndex = 0
 
         if lastIndex == -1:
-            lastIndex = self.__procCount
+            lastIndex = self.__procCount - 1
 
         for i in range(firstIndex, lastIndex + 1, 1):
             procInfo = self.GetProcInfo(i)


### PR DESCRIPTION
(Tested with kb7 only)

Iterating with -1 as lastIndex raises an exception.
If lastIndex is -1, as we are iterating until lastIndex+1, we are going out of bound.
This PR fixes it.